### PR TITLE
Add compactMonths prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ And somewhere in your stylesheet build process...
 Name | Type | Description
 -----|------|-------------
 `className` | string | Class name for the calendar's container element
+`compactMonths` | bool | A flag that combines all of the months into one continuous block of days, with the month header split out and positioned along the left edge of the container. This sets `position: absolute`, `right: 100%`, and `margin: 0` on the month header class, so override those properties in your CSS if you think you have better ideas.
 `dayAbbrevs` | Array.&lt;string&gt; | Array of day names, starting with Sunday. Defaults to `['Su', 'M', 'T', 'W', 'Th', 'F', 'Sa']`.
 `dayHeaderClassName` | string | Class name for the day header container element
 `dayHeaderStyle` | Enum | Determines where the day column headers are rendered. Can be one of `Calendar.DayHeaderStyles.InFirstMonth` (the default), `Calendar.DayHeaderStyles.AboveFirstMonth`, or `Calendar.DayHeaderStyles.InEveryMonth`

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ const DayHeaderStyles = {
 export default function Calendar(props) {
   const {
     className,
+    compactMonths,
     dayAbbrevs,
     dayHeaderClassName,
     dayHeaderStyle,
@@ -59,7 +60,10 @@ export default function Calendar(props) {
 
   const firstDay = moment(firstRenderedDay);
   const lastDay = moment(lastRenderedDay);
-  const months = getMonthsInRange(firstDay, lastDay);
+  const months = (compactMonths ?
+    [firstDay] :
+    getMonthsInRange(firstDay, lastDay)
+  );
 
   return (
     <div className={className}>
@@ -81,15 +85,19 @@ export default function Calendar(props) {
           )}
           headerClassName={monthHeaderClassName}
           headerFormat={monthHeaderFormat}
+          headerInsideDay={compactMonths}
           includeDayHeaders={
             dayHeaderStyle === DayHeaderStyles.InEveryMonth ||
             (dayHeaderStyle === DayHeaderStyles.InFirstMonth && idx === 0)
           }
           key={firstOfMonth.format('YYYYMM')}
-          lastDay={moment.min(
-            firstOfMonth.clone().endOf('month'),
-            lastDay
-          )}
+          lastDay={compactMonths ?
+            lastDay :
+            moment.min(
+              firstOfMonth.clone().endOf('month'),
+              lastDay
+            )
+          }
           renderDay={renderDay}
           weekClassName={weekClassName}
         />
@@ -100,6 +108,7 @@ export default function Calendar(props) {
 
 Calendar.propTypes = {
   className: PropTypes.string,
+  compactMonths: PropTypes.bool.isRequired,
 
   // Array of 7 strings to use as column headers for days. Start with Sunday.
   dayAbbrevs: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -117,6 +126,7 @@ Calendar.propTypes = {
 };
 
 Calendar.defaultProps = {
+  compactMonths: false,
   dayAbbrevs: ['Su', 'M', 'T', 'W', 'Th', 'F', 'Sa'],
   dayHeaderStyle: DayHeaderStyles.InFirstMonth,
   monthHeaderFormat: 'MMMM YYYY',

--- a/src/month.js
+++ b/src/month.js
@@ -42,6 +42,12 @@ const daysInRange = _.memoize(
  */
 const partitionByWeek = _.memoize(fp.groupBy(fp.invoke('week')));
 
+/* NOTE(Jeremy):
+ * This is _usually_ a single month to be rendered. However, if the outer
+ * calendar component has the `compactMonths` flag set, then this gets
+ * `headerInsideDay`, and at that point should only be considered a collection
+ * of days, not limited to a single month.
+ */
 export default function CalendarMonth(props) {
   const {
     className,
@@ -50,6 +56,7 @@ export default function CalendarMonth(props) {
     firstDay,
     headerClassName,
     headerFormat,
+    headerInsideDay,
     includeDayHeaders,
     lastDay,
     renderDay,
@@ -60,10 +67,18 @@ export default function CalendarMonth(props) {
   const numberOfWeeks = _.size(dayWeeks);
 
   return (
-    <div className={className}>
-      <h3 className={headerClassName}>
-        {firstDay.format(headerFormat)}
-      </h3>
+    <div
+      className={classNames(
+        className,
+        { 'tt-cal-headerInsideDay': headerInsideDay }
+      )}
+    >
+      { headerInsideDay ?
+        null :
+        <h3 className={headerClassName}>
+          {firstDay.format(headerFormat)}
+        </h3>
+      }
       { includeDayHeaders ?
         <CalendarDayHeaders
           className={dayHeaderClassName}
@@ -90,6 +105,24 @@ export default function CalendarMonth(props) {
               {
                 days.map((day) => (
                   <div key={day.format('YYYYMMDD')} className="tt-cal-day">
+                    { (
+                        headerInsideDay && (
+                          // We're either the first day rendered, or
+                          // the first day of a new month.
+                          day.isSame(firstDay) ||
+                          day.date() === 1
+                        )
+                      ) ?
+                      <h3
+                        className={classNames(
+                          'tt-cal-inlineMonthHeader',
+                          headerClassName
+                        )}
+                      >
+                        {day.format(headerFormat)}
+                      </h3> :
+                      null
+                    }
                     {renderDay(day)}
                   </div>
                 ))
@@ -109,6 +142,7 @@ CalendarMonth.propTypes = {
   firstDay: PropTypes.instanceOf(moment).isRequired,
   headerClassName: PropTypes.string,
   headerFormat: PropTypes.string.isRequired,
+  headerInsideDay: PropTypes.bool.isRequired,
   includeDayHeaders: PropTypes.bool.isRequired,
   lastDay: PropTypes.instanceOf(moment).isRequired,
   renderDay: PropTypes.func.isRequired,
@@ -116,5 +150,6 @@ CalendarMonth.propTypes = {
 };
 
 CalendarMonth.defaultProps = {
+  headerInsideDay: false,
   includeDayHeaders: true,
 };

--- a/src/month.js
+++ b/src/month.js
@@ -103,29 +103,33 @@ export default function CalendarMonth(props) {
                 null
               }
               {
-                days.map((day) => (
-                  <div key={day.format('YYYYMMDD')} className="tt-cal-day">
-                    { (
-                        headerInsideDay && (
-                          // We're either the first day rendered, or
-                          // the first day of a new month.
-                          day.isSame(firstDay) ||
-                          day.date() === 1
-                        )
-                      ) ?
-                      <h3
-                        className={classNames(
-                          'tt-cal-inlineMonthHeader',
-                          headerClassName
-                        )}
-                      >
-                        {day.format(headerFormat)}
-                      </h3> :
-                      null
-                    }
-                    {renderDay(day)}
-                  </div>
-                ))
+                days.map((day) => {
+                  const shouldRenderHeader = (
+                    headerInsideDay && (
+                      // We're either the first day rendered, or
+                      // the first day of a new month.
+                      day.isSame(firstDay) ||
+                      day.date() === 1
+                    )
+                  );
+
+                  return (
+                    <div key={day.format('YYYYMMDD')} className="tt-cal-day">
+                      { shouldRenderHeader ?
+                        <h3
+                          className={classNames(
+                            'tt-cal-inlineMonthHeader',
+                            headerClassName
+                          )}
+                        >
+                          {day.format(headerFormat)}
+                        </h3> :
+                        null
+                      }
+                      {renderDay(day)}
+                    </div>
+                  );
+                })
               }
             </div>
           ))

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,6 +17,17 @@
   text-align: center;
 }
 
+.tt-cal-headerInsideDay {
+  /* The month header element will need to be position: absolute in this case */
+  position: relative;
+}
+
+.tt-cal-inlineMonthHeader {
+  position: absolute;
+  right: 100%;
+  margin: 0;
+}
+
 .tt-cal-week {
   display: flex;
 


### PR DESCRIPTION
This allows for an alternate view, where all of the days are in one big blob, and the month names are on the side.

Example screenshot (with some additional styling provided using `monthHeaderClassName`)
<img width="849" alt="screen shot 2017-03-30 at 2 53 01 pm" src="https://cloud.githubusercontent.com/assets/1740479/24521165/34197f72-1559-11e7-8212-eb20f0dbcfe9.png">


@TodayTix/web 