### PR TITLE
Add gutterWidth prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Name | Type | Description | Since Version
 `dayHeaderClassName` | string | Class name for the day header container element | 1.2.0
 `dayHeaderStyle` | Enum | Determines where the day column headers are rendered. Can be one of `Calendar.DayHeaderStyles.InFirstMonth` (the default), `Calendar.DayHeaderStyles.AboveFirstMonth`, or `Calendar.DayHeaderStyles.InEveryMonth` | 1.0.0
 `firstRenderedDay` | _varied_ | The first date that will be rendered as part of the calendar. Can be any type that [moment's constructor](http://momentjs.com/docs/#/parsing/) supports. | 1.0.0
+`gutterWidth` | string | CSS value to use as the gutter between columns | 1.5.0
 `lastRenderedDay` | _varied_ | The last date that will be rendered as part of the calendar. Can be any type that [moment's constructor](http://momentjs.com/docs/#/parsing/) supports. | 1.0.0
 `monthClassName` | string | Class name to add to each month element | 1.0.0
 `monthHeaderFormat` | string | Format of the month header text. See [moment.format](http://momentjs.com/docs/#/displaying/format/) for the available options. Defaults to `'MMMM YYYY'`. | 1.0.0

--- a/src/day-headers.js
+++ b/src/day-headers.js
@@ -12,12 +12,19 @@ export default function CalendarDayHeaders(props) {
   const {
     className,
     dayAbbrevs,
+    gutterWidth,
   } = props;
 
   return (
     <div className={classNames('tt-cal-dayHeaders', className)}>
-      {_.range(firstWeekday, firstWeekday + 7).map((weekday) => (
-        <div key={weekday % 7} className="tt-cal-columnHeader">
+      {_.range(firstWeekday, firstWeekday + 7).map((weekday, idx) => (
+        <div
+          key={weekday % 7}
+          className="tt-cal-columnHeader"
+          style={{
+            marginLeft: (idx === 0 ? null : gutterWidth)
+          }}
+        >
           {dayAbbrevs[weekday % 7]}
         </div>
       ))}
@@ -28,4 +35,5 @@ export default function CalendarDayHeaders(props) {
 CalendarDayHeaders.propTypes = {
   className: PropTypes.string,
   dayAbbrevs: PropTypes.arrayOf(PropTypes.string).isRequired,
+  gutterWidth: PropTypes.string,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ export default function Calendar(props) {
     dayHeaderClassName,
     dayHeaderStyle,
     firstRenderedDay,
+    gutterWidth,
     lastRenderedDay,
     monthClassName,
     monthHeaderClassName,
@@ -72,6 +73,7 @@ export default function Calendar(props) {
         <CalendarDayHeaders
           className={dayHeaderClassName}
           dayAbbrevs={dayAbbrevs}
+          gutterWidth={gutterWidth}
         /> :
         null
       }
@@ -84,9 +86,10 @@ export default function Calendar(props) {
             firstOfMonth,
             firstDay
           )}
+          gutterWidth={gutterWidth}
           headerClassName={monthHeaderClassName}
           headerInsideDay={compactMonths}
-					 headerFormat={monthHeaderFormat}
+          headerFormat={monthHeaderFormat}
           includeDayHeaders={
             dayHeaderStyle === DayHeaderStyles.InEveryMonth ||
             (dayHeaderStyle === DayHeaderStyles.InFirstMonth && idx === 0)
@@ -117,10 +120,11 @@ Calendar.propTypes = {
   dayHeaderClassName: PropTypes.string,
   dayHeaderStyle: PropTypes.oneOf(_.values(DayHeaderStyles)),
   firstRenderedDay: dayType.isRequired,
+  gutterWidth: PropTypes.string,
   lastRenderedDay: dayType.isRequired,
   monthClassName: PropTypes.string,
   monthHeaderClassName: PropTypes.string,
-	 monthHeaderFormat: PropTypes.string,
+	monthHeaderFormat: PropTypes.string,
 
   // Function that takes a moment instance and returns a single ReactElement.
   renderDay: PropTypes.func.isRequired,

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,14 +2,15 @@
   --day-width: calc((1/7) * 100%);
 }
 
-.tt-cal-dayHeaders {
+.tt-cal-dayHeaders,
+.tt-cal-week {
   display: flex;
 }
 
 .tt-cal-columnHeader,
 .tt-cal-dummyDay,
 .tt-cal-day {
-  flex: 0 0 var(--day-width);
+  flex: 0 1 var(--day-width);
   width: var(--day-width);
 }
 
@@ -26,21 +27,4 @@
   position: absolute;
   right: 100%;
   margin: 0;
-}
-
-.tt-cal-week {
-  display: flex;
-
-  &:first-child {
-    justify-content: flex-end;
-  }
-
-  &:last-child {
-    /* NOTE(Jeremy):
-     * We have this declared after the :first-child styles because if there's
-     * only one row, we insert dummyDay divs at the beginning of the row to get
-     * the alignment correct, which means the days need to be left-aligned.
-     */
-    justify-content: flex-start;
-  }
 }


### PR DESCRIPTION
Margin between day wrappers wasn't easy for users to access. Now it's a
prop that adds a bunch of inline styles and lets flexbox handle the
complicated math-y parts.