### PR TITLE
Consistently respect the locale set on momentjs

### DIFF
--- a/src/day-headers.js
+++ b/src/day-headers.js
@@ -3,17 +3,14 @@ import moment from 'moment';
 import _ from 'lodash';
 import classNames from 'classnames';
 
-// A bit of a roundabout way to get what the first day of the week is, according
-// to the locale used by moment. This works because .weekday is locale-specific,
-// and .day always starts with Sunday as 0.
-const firstWeekday = moment().weekday(0).day();
-
 export default function CalendarDayHeaders(props) {
   const {
     className,
     dayAbbrevs,
     gutterWidth,
   } = props;
+
+  const firstWeekday = moment.localeData().firstDayOfWeek();
 
   return (
     <div className={classNames('tt-cal-dayHeaders', className)}>

--- a/src/month.js
+++ b/src/month.js
@@ -21,8 +21,10 @@ const daysInRange = _.memoize(
     return arr;
   },
   // memoization key
+  // NOTE(Jeremy): The "e" is the locale-specific day of the week. If that
+  // changes, it should invalidate the cache.
   (firstDay, lastDay) =>
-    `${firstDay.format('YYYYMMDD')}-${lastDay.format('YYYYMMDD')}`
+    `${firstDay.format('eYYYYMMDD')}-${lastDay.format('eYYYYMMDD')}`
 );
 
 /**
@@ -89,6 +91,7 @@ export default function CalendarMonth(props) {
   } = props;
 
   const dayWeeks = partitionByWeek(daysInRange(firstDay, lastDay));
+  const firstWeekday = moment.localeData().firstDayOfWeek();
 
   return (
     <div
@@ -163,7 +166,7 @@ export default function CalendarMonth(props) {
 
               {/* Right dummy days */}
               { parseInt(week, 10) === lastDay.week() ?
-                dummyDays(7 - (lastDay.weekday() + 1), {
+                dummyDays(7 - (lastDay.weekday() + 1) - firstWeekday, {
                   gutterWidth,
                   firstHasMargin: true,
                 }) :


### PR DESCRIPTION
I had some overly aggressive caching that wasn't catching when someone changed `moment.locale()`