### PR TITLE
Use locale of moment instance, instead of global moment

### DIFF
--- a/src/day-headers.js
+++ b/src/day-headers.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import moment from 'moment';
 import _ from 'lodash';
 import classNames from 'classnames';
 
@@ -7,10 +6,9 @@ export default function CalendarDayHeaders(props) {
   const {
     className,
     dayAbbrevs,
+    firstWeekday,
     gutterWidth,
   } = props;
-
-  const firstWeekday = moment.localeData().firstDayOfWeek();
 
   return (
     <div className={classNames('tt-cal-dayHeaders', className)}>
@@ -32,5 +30,6 @@ export default function CalendarDayHeaders(props) {
 CalendarDayHeaders.propTypes = {
   className: PropTypes.string,
   dayAbbrevs: PropTypes.arrayOf(PropTypes.string).isRequired,
+  firstWeekday: PropTypes.number.isRequired,
   gutterWidth: PropTypes.string,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -76,6 +76,7 @@ export default function Calendar(props) {
     [firstDay] :
     getMonthsInRange(firstDay, lastDay)
   );
+  const firstWeekday = firstDay.localeData().firstDayOfWeek();
 
   return (
     <div className={className}>
@@ -83,6 +84,7 @@ export default function Calendar(props) {
         <CalendarDayHeaders
           className={dayHeaderClassName}
           dayAbbrevs={dayAbbrevs}
+          firstWeekday={firstWeekday}
           gutterWidth={gutterWidth}
         /> :
         null
@@ -96,6 +98,7 @@ export default function Calendar(props) {
             firstOfMonth,
             firstDay
           )}
+          firstWeekday={firstWeekday}
           gutterWidth={gutterWidth}
           headerClassName={monthHeaderClassName}
           headerInsideDay={compactMonths}

--- a/src/month.js
+++ b/src/month.js
@@ -79,6 +79,7 @@ export default function CalendarMonth(props) {
     dayAbbrevs,
     dayHeaderClassName,
     firstDay,
+    firstWeekday,
     gutterWidth,
     headerClassName,
     headerFormat,
@@ -109,6 +110,7 @@ export default function CalendarMonth(props) {
         <CalendarDayHeaders
           className={dayHeaderClassName}
           dayAbbrevs={dayAbbrevs}
+          firstWeekday={firstWeekday}
           gutterWidth={gutterWidth}
         /> :
         null
@@ -184,6 +186,7 @@ CalendarMonth.propTypes = {
   dayAbbrevs: PropTypes.arrayOf(PropTypes.string).isRequired,
   dayHeaderClassName: PropTypes.string,
   firstDay: PropTypes.instanceOf(moment).isRequired,
+  firstWeekday: PropTypes.number,
   gutterWidth: PropTypes.string,
   headerClassName: PropTypes.string,
   headerFormat: PropTypes.string.isRequired,

--- a/test/layout.js
+++ b/test/layout.js
@@ -57,6 +57,7 @@ test('has 7 children in every week across multiple months', t => {
 test('includes margins on all but first day header', t => {
   const wrapper = shallow(<DayHeaders
     dayAbbrevs={abbrevs}
+    firstWeekday={0}
     gutterWidth="23px"
   />);
 

--- a/test/locale.js
+++ b/test/locale.js
@@ -16,19 +16,15 @@ test.afterEach(t => {
   moment.locale(t.context.prevLocale);
 });
 
-test.serial('renders day headers in en-gb starting with Monday', t => {
-  moment.locale('en-gb');
-
-  const wrapper = shallow(<DayHeaders dayAbbrevs={abbrevs} />);
+test('respects the firstWeekday prop for Monday', t => {
+  const wrapper = shallow(<DayHeaders dayAbbrevs={abbrevs} firstWeekday={1} />);
   const firstHeader = wrapper.find('.tt-cal-columnHeader').first();
 
   t.is(firstHeader.text(), abbrevs[1]);
 });
 
-test.serial('renders day headers in en starting with Sunday', t => {
-  moment.locale('en');
-
-  const wrapper = shallow(<DayHeaders dayAbbrevs={abbrevs} />);
+test('respects the firstWeekday prop for Monday', t => {
+  const wrapper = shallow(<DayHeaders dayAbbrevs={abbrevs} firstWeekday={0} />);
   const firstHeader = wrapper.find('.tt-cal-columnHeader').first();
 
   t.is(firstHeader.text(), abbrevs[0]);
@@ -80,7 +76,7 @@ test.serial('has the correct number of leading dummy days in en-gb', t => {
 test.serial('has the correct number of trailing dummy days in en-gb', t => {
   moment.locale('en-gb');
 
-  // Go from Wednesday April 25 to Thursday May 25.
+  // Go from Wednesday April 26 to Thursday May 25.
   const wrapper = render(<TTReactCalendar
     firstRenderedDay="2017-04-26"
     lastRenderedDay="2017-05-25"
@@ -108,7 +104,7 @@ test.serial('has the correct number of leading dummy days in en', t => {
 test.serial('has the correct number of trailing dummy days in en', t => {
   moment.locale('en');
 
-  // Go from Wednesday April 25 to Thursday May 25.
+  // Go from Wednesday April 26 to Thursday May 25.
   const wrapper = render(<TTReactCalendar
     firstRenderedDay="2017-04-26"
     lastRenderedDay="2017-05-25"
@@ -117,4 +113,26 @@ test.serial('has the correct number of trailing dummy days in en', t => {
   const dummyDays = lastWeek.find('.tt-cal-dummyDay');
 
   t.is(dummyDays.length, 2);
+});
+
+test.serial('respects the instance locale over the global one', t => {
+  moment.locale('en');
+
+  // Go from Wednesday April 26 to Thursday May 25.
+  const firstDay = moment('2017-04-26').locale('en-gb');
+  const lastDay = moment('2017-05-25').locale('en-gb');
+
+  const wrapper = render(<TTReactCalendar
+    dayHeaderStyle={TTReactCalendar.DayHeaderStyles.AboveFirstMonth}
+    firstRenderedDay={firstDay}
+    lastRenderedDay={lastDay}
+  />);
+
+  const firstWeek = wrapper.find('.tt-cal-week').first();
+  const firstWeekDummyDays = firstWeek.find('.tt-cal-dummyDay');
+  const dayHeaders = wrapper.find('.tt-cal-dayHeaders');
+  const firstHeader = dayHeaders.find('.tt-cal-columnHeader').first();
+
+  t.is(firstWeekDummyDays.length, 2, 'incorrect number of leading dummy days');
+  t.is(firstHeader.text(), abbrevs[1]);
 });


### PR DESCRIPTION
Relying on the locale of the global moment singleton can run into issues if NPM behaves unpredictably. For instance, we recently saw it unexpectedly installing a second version of moment for this library, which then didn't have the same locale being set on it. Since we already can have an instance passed in as a prop, we can just use the locale from that, and since we're wrapping it with a moment object even if it *isn't* passed in as a moment object, this should fall back to the global moment object, which was the previous behavior.

Hooray for solutions without breaking changes!