### PR TITLE
Ensure weeks are ordered correctly across week-years

### DIFF
--- a/src/month.js
+++ b/src/month.js
@@ -42,7 +42,11 @@ const daysInRange = _.memoize(
  * @param  {Array.<moment>} days Array of moment day objects to partition
  * @return {Array.<Array.<moment>>}
  */
-const partitionByWeek = _.memoize(fp.groupBy(fp.invoke('week')));
+const partitionByWeek = _.memoize(_.flow(
+  fp.groupBy(fp.invoke('week')),
+  fp.values,
+  fp.sortBy(fp.head)
+));
 
 /**
  * Generates an array of dummy day elements to fill up space and make alignment
@@ -117,9 +121,9 @@ export default function CalendarMonth(props) {
       }
       <div>
         {
-          _.map(dayWeeks, (days, week) => (
+          _.map(dayWeeks, (days) => (
             <div
-              key={week}
+              key={days[0].week()}
               className={classNames('tt-cal-week', weekClassName)}
             >
               {/* Left dummy days */}
@@ -166,7 +170,7 @@ export default function CalendarMonth(props) {
               }
 
               {/* Right dummy days */}
-              { parseInt(week, 10) === lastDay.week() ?
+              { days[0].week() === lastDay.week() ?
                 dummyDays(7 - (lastDay.weekday() + 1), {
                   gutterWidth,
                   firstHasMargin: true,

--- a/test/layout.js
+++ b/test/layout.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import React from 'react';
 import { render, shallow } from 'enzyme';
 import $ from 'cheerio';
+import moment from 'moment';
 
 import TTReactCalendar from '../src';
 import DayHeaders from '../src/day-headers';
@@ -72,3 +73,18 @@ test('includes margins on all but first day header', t => {
     t.is(header.prop('style').marginLeft, expected);
   });
 });
+
+test('orders weeks correctly with weeks spanning years', t => {
+  // Background: Dec 31, 2017 is in week 1 of 2018 (in US locale), which put it
+  // at the top of the month instead of the bottom.
+  const wrapper = render(<TTReactCalendar
+    firstRenderedDay={moment('2017-12-24').locale('en')}
+    lastRenderedDay={moment('2017-12-31').locale('en')}
+    renderDay={(day) => day.format('YYYYMMDD')}
+  />);
+
+  const firstWeek = wrapper.find('.tt-cal-week').first();
+  const firstDay = firstWeek.find('.tt-cal-day').first();
+
+  t.is(firstDay.text(), '20171224');
+})


### PR DESCRIPTION
Dec 31 2017 is in week 1 of 2018, and 1 is less than 52, but we still want Dec 31 to be rendered at the bottom of December.