### PR TITLE
Include UTC offset in memoization keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ import CalendarMonth from './month';
  * @return {string}
  */
 const monthKey = (day) =>
-  `${day.localeData().firstDayOfWeek()}${day.format('YYYYMM')}`;
+  `${day.localeData().firstDayOfWeek()}${day.format('YYYYMMZZ')}`;
 
 /**
  * Takes two inclusive endpoints and returns an array of moment objects for the

--- a/src/month.js
+++ b/src/month.js
@@ -24,7 +24,7 @@ const daysInRange = _.memoize(
   // NOTE(Jeremy): The "e" is the locale-specific day of the week. If that
   // changes, it should invalidate the cache.
   (firstDay, lastDay) =>
-    `${firstDay.format('eYYYYMMDD')}-${lastDay.format('eYYYYMMDD')}`
+    `${firstDay.format('eYYYYMMDDZZ')}-${lastDay.format('eYYYYMMDDZZ')}`
 );
 
 /**

--- a/test/layout.js
+++ b/test/layout.js
@@ -87,4 +87,28 @@ test('orders weeks correctly with weeks spanning years', t => {
   const firstDay = firstWeek.find('.tt-cal-day').first();
 
   t.is(firstDay.text(), '20171224');
-})
+});
+
+test('inserts dummy days when day tz offset is less than the local tz', t => {
+  const localOffset = moment().utcOffset();
+  const firstDay = moment('2017-05-30').startOf('day').utcOffset(localOffset - 60, true);
+  const lastDay = firstDay.clone().add(20, 'days');
+
+  // Do a render that we won't use, first, to make sure that we're testing
+  // against over-eager memoization.
+  render(<TTReactCalendar
+    compactMonths={true}
+    firstRenderedDay={firstDay.clone().utcOffset(localOffset, true)}
+    lastRenderedDay={lastDay.clone().utcOffset(localOffset, true)}
+  />);
+  const wrapper = render(<TTReactCalendar
+    compactMonths={true}
+    firstRenderedDay={firstDay}
+    lastRenderedDay={firstDay.clone().add(20, 'days')}
+  />);
+
+  const firstWeek = wrapper.find('.tt-cal-week').first();
+  const dummyDays = firstWeek.find('.tt-cal-dummyDay');
+
+  t.is(dummyDays.length, 2);
+});


### PR DESCRIPTION
Without this fix, the `days[0].isSame(firstDay)` check in `month.js` to determine whether or not to include dummyDay elements returns false if a non-matching timezone date was pulled from the memoization cache.

It's almost like cache invalidation is a hard problem or something.